### PR TITLE
Preventing hidden NaNs in `exp`

### DIFF
--- a/jaxlie/_so3.py
+++ b/jaxlie/_so3.py
@@ -326,7 +326,7 @@ class SO3(jdc.EnforcedAnnotationsMixin, _base.SOBase):
         safe_theta = jnp.sqrt(
             jnp.where(
                 use_taylor,
-                0.0,  # Any constant value should do here.
+                1.0,  # Any constant value should do here.
                 theta_squared,
             )
         )


### PR DESCRIPTION
## Why ? 

In `SO3.exp`, there is a shim to prevent NaNs by using a jnp.where with a Taylor approximation for values under epsilon. However, this is still catched by the jax_debug_nans configuration, even when there are no NaNs present in the final outputs (the NaNs appear in the intermediate computations).

## Contents of this PR
This can be solved easily by changing the arbitrary value from 0.0 to 1.0, thus removing the divisions by 0 and preventing the catch by the JAX NaN debugger.