### PR TITLE
Faster quaternion multiplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Where each group supports:
   **`adjoint()`**, **`apply()`**, **`multiply()`**, **`inverse()`**,
   **`identity()`**, **`from_matrix()`**, and **`as_matrix()`** operations. (see
   [./examples/se3_example.py](./examples/se3_basics.py))
+- Taylor approximations near singularities.
 - Helpers for optimization on manifolds (see
   [./examples/se3_optimization.py](./examples/se3_optimization.py),
   <code>jaxlie.<strong>manifold.\*</strong></code>).
@@ -78,24 +79,10 @@ pip install jaxlie
 
 ---
 
-### In the wild
-
-- [jaxfg](https://github.com/brentyi/jaxfg) applies `jaxlie` to nonlinear least
-  squares problems with block-sparse structure. (for pose graph optimization,
-  bundle adjustment, etc)
-- [tensorf-jax](https://github.com/brentyi/tensorf-jax) is an unofficial
-  implementation of
-  [Tensorial Radiance Fields (Chen et al, ECCV 2022)](https://apchenstu.github.io/TensoRF/)
-  using `jaxlie`.
-  ![Render of a lego](https://github.com/brentyi/tensorf-jax/raw/main/lego_render.gif)
-
----
-
 ### Misc
 
-`jaxlie` was originally written for our IROS 2021 paper
-([link](https://github.com/brentyi/dfgo)). If it's useful for you, you're
-welcome to cite:
+`jaxlie` was originally written when I was learning about Lie groups for our IROS 2021 paper
+([link](https://github.com/brentyi/dfgo)):
 
 ```
 @inproceedings{yi2021iros,

--- a/jaxlie/_se2.py
+++ b/jaxlie/_se2.py
@@ -138,7 +138,7 @@ class SE2(_base.SEBase[SO2]):
             jax.Array,
             jnp.where(
                 use_taylor,
-                jnp.ones_like(theta),  # Any non-zero value should do here.
+                1.0,  # Any non-zero value should do here.
                 theta,
             ),
         )
@@ -193,7 +193,7 @@ class SE2(_base.SEBase[SO2]):
         # reverse-mode AD.
         safe_cos_minus_one = jnp.where(
             use_taylor,
-            jnp.ones_like(cos_minus_one),  # Any non-zero value should do here.
+            1.0,  # Any non-zero value should do here.
             cos_minus_one,
         )
 

--- a/jaxlie/_se3.py
+++ b/jaxlie/_se3.py
@@ -131,7 +131,7 @@ class SE3(_base.SEBase[SO3]):
             jax.Array,
             jnp.where(
                 use_taylor,
-                jnp.ones_like(theta_squared),  # Any non-zero value should do here.
+                1.0,  # Any non-zero value should do here.
                 theta_squared,
             ),
         )
@@ -173,7 +173,7 @@ class SE3(_base.SEBase[SO3]):
         # reverse-mode AD.
         theta_squared_safe = jnp.where(
             use_taylor,
-            jnp.ones_like(theta_squared),  # Any non-zero value should do here.
+            1.0,  # Any non-zero value should do here.
             theta_squared,
         )
         del theta_squared

--- a/jaxlie/_so3.py
+++ b/jaxlie/_so3.py
@@ -385,7 +385,7 @@ class SO3(_base.SOBase):
         safe_theta = jnp.sqrt(
             jnp.where(
                 use_taylor,
-                jnp.ones_like(theta_squared),  # Any constant value should do here.
+                1.0,  # Any constant value should do here.
                 theta_squared,
             )
         )

--- a/jaxlie/_so3.py
+++ b/jaxlie/_so3.py
@@ -311,16 +311,59 @@ class SO3(_base.SOBase):
 
     @override
     def multiply(self, other: SO3) -> SO3:
-        w0, x0, y0, z0 = jnp.moveaxis(self.wxyz, -1, 0)
-        w1, x1, y1, z1 = jnp.moveaxis(other.wxyz, -1, 0)
+        # Original implementation:
+        #
+        # w0, x0, y0, z0 = jnp.moveaxis(self.wxyz, -1, 0)
+        # w1, x1, y1, z1 = jnp.moveaxis(other.wxyz, -1, 0)
+        # return SO3(
+        #     wxyz=jnp.stack(
+        #         [
+        #             -x0 * x1 - y0 * y1 - z0 * z1 + w0 * w1,
+        #             x0 * w1 + y0 * z1 - z0 * y1 + w0 * x1,
+        #             -x0 * z1 + y0 * w1 + z0 * x1 + w0 * y1,
+        #             x0 * y1 - y0 * x1 + z0 * w1 + w0 * z1,
+        #         ],
+        #         axis=-1,
+        #     )
+        # )
+        #
+        # This is great/fine/standard, but there are a lot of operations. This
+        # puts a lot of burden on the JIT compiler.
+        #
+        # Here's another implementation option. The JIT time is much faster, but the
+        # runtime is ~10% slower:
+        #
+        # inds = jnp.array([0, 1, 2, 3, 1, 0, 3, 2, 2, 3, 0, 1, 3, 2, 1, 0])
+        # signs = jnp.array([1, -1, -1, -1, 1, 1, -1, 1, 1, 1, 1, -1, 1, -1, 1, 1])
+        # return SO3(
+        #     wxyz=jnp.einsum(
+        #         "...ij,...j->...i",
+        #         (self.wxyz[..., inds] * signs).reshape((*self.wxyz.shape, 4)),
+        #         other.wxyz,
+        #     )
+        # )
+        #
+        # For pose graph optimization on the sphere2500 dataset, the following
+        # speeds up *overall* JIT times by over 35%, without any runtime
+        # penalties.
+
+        # Hamilton product constants.
+        terms_i = jnp.array([[0, 1, 2, 3], [0, 1, 2, 3], [0, 2, 3, 1], [0, 3, 1, 2]])
+        terms_j = jnp.array([[0, 1, 2, 3], [1, 0, 3, 2], [2, 0, 1, 3], [3, 0, 2, 1]])
+        signs = jnp.array(
+            [
+                [1, -1, -1, -1],
+                [1, 1, 1, -1],
+                [1, 1, 1, -1],
+                [1, 1, 1, -1],
+            ]
+        )
+
+        # Compute all components at once
+        q_outer = jnp.einsum("...i,...j->...ij", self.wxyz, other.wxyz)
         return SO3(
-            wxyz=jnp.stack(
-                [
-                    -x0 * x1 - y0 * y1 - z0 * z1 + w0 * w1,
-                    x0 * w1 + y0 * z1 - z0 * y1 + w0 * x1,
-                    -x0 * z1 + y0 * w1 + z0 * x1 + w0 * y1,
-                    x0 * y1 - y0 * x1 + z0 * w1 + w0 * z1,
-                ],
+            jnp.sum(
+                signs * q_outer[..., terms_i, terms_j],
                 axis=-1,
             )
         )

--- a/jaxlie/manifold/_deltas.py
+++ b/jaxlie/manifold/_deltas.py
@@ -1,6 +1,6 @@
 """Helpers for recursively applying tangent-space deltas."""
 
-from typing import Any, Callable, TypeVar, Union, cast, overload
+from typing import Any, TypeVar, Union, overload
 
 import jax
 import numpy as onp

--- a/tests/test_broadcast.py
+++ b/tests/test_broadcast.py
@@ -3,12 +3,7 @@
 from typing import Tuple, Type
 
 import numpy as onp
-from hypothesis import given, settings
-from hypothesis import strategies as st
-from jax import numpy as jnp
 from utils import (
-    assert_arrays_close,
-    assert_transforms_close,
     general_group_test,
     sample_transform,
 )

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -3,10 +3,12 @@
 from typing import Tuple, Type
 
 import jax
+import jaxlie
 import numpy as onp
 import pytest
 from jax import numpy as jnp
 from jax import tree_util
+
 from utils import (
     assert_arrays_close,
     assert_transforms_close,
@@ -14,8 +16,6 @@ from utils import (
     general_group_test_faster,
     sample_transform,
 )
-
-import jaxlie
 
 
 @general_group_test
@@ -67,6 +67,13 @@ def test_sgd(Group: Type[jaxlie.MatrixLieGroup], batch_axes: Tuple[int, ...]):
 
     transform = Group.exp(sample_transform(Group, batch_axes).log())
     original_loss = loss(transform)
+
+    assert_arrays_close(
+        jaxlie.manifold.grad(lambda transform: (loss(transform), None), has_aux=True)(
+            transform
+        ),
+        jaxlie.manifold.grad(loss)(transform),
+    )
 
     @jax.jit
     def step(t):

--- a/tests/test_manifold.py
+++ b/tests/test_manifold.py
@@ -71,7 +71,7 @@ def test_sgd(Group: Type[jaxlie.MatrixLieGroup], batch_axes: Tuple[int, ...]):
     assert_arrays_close(
         jaxlie.manifold.grad(lambda transform: (loss(transform), None), has_aux=True)(
             transform
-        ),
+        )[0],
         jaxlie.manifold.grad(loss)(transform),
     )
 


### PR DESCRIPTION
For pose graph optimization on the sphere2500 dataset, this speeds up overall JIT time by ~35%, from >7 seconds on my machine to 4.5 seconds. Runtime difference is insignificant.

When multiplying quaternions with batch axis `(4096,)`, here's the jaxpr now:

```
{ lambda a:f32[4096,4] b:f32[4096,4]; . let
    c:f32[4096,4] = pjit[
      name=multiply
      jaxpr={ lambda d:i32[4,4] e:i32[4,4] f:i32[4,4]; g:f32[4096,4] h:f32[4096,4]. let
          i:f32[4096,4,4] = dot_general[
            dimension_numbers=(([], []), ([0], [0]))
            preferred_element_type=float32
          ] g h
          j:bool[4,4] = lt d 0
          k:i32[4,4] = add d 4
          l:i32[4,4] = select_n j d k
          m:bool[4,4] = lt e 0
          n:i32[4,4] = add e 4
          o:i32[4,4] = select_n m e n
          p:i32[4,4,1] = broadcast_in_dim[
            broadcast_dimensions=(0, 1)
            shape=(4, 4, 1)
          ] l
          q:i32[4,4,1] = broadcast_in_dim[
            broadcast_dimensions=(0, 1)
            shape=(4, 4, 1)
          ] o
          r:i32[4,4,2] = concatenate[dimension=2] p q
          s:f32[4096,4,4] = gather[
            dimension_numbers=GatherDimensionNumbers(offset_dims=(0,), collapsed_slice_dims=(1, 2), start_index_map=(1, 2), operand_batching_dims=(), start_indices_batching_dims=())
            fill_value=None
            indices_are_sorted=False
            mode=GatherScatterMode.PROMISE_IN_BOUNDS
            slice_sizes=(4096, 1, 1)
            unique_indices=False
          ] i r
          t:f32[4,4] = convert_element_type[new_dtype=float32 weak_type=False] f
          u:f32[1,4,4] = broadcast_in_dim[
            broadcast_dimensions=(1, 2)
            shape=(1, 4, 4)
          ] t
          v:f32[4096,4,4] = mul u s
          w:f32[4096,4] = reduce_sum[axes=(2,)] v
        in (w,) }
    ] a b
  in (c,) }
```

Compared to before:

```
{ lambda a:f32[4096,4] b:f32[4096,4]; . let
    c:f32[4096,4] = pjit[
      name=multiply
      jaxpr={ lambda ; d:f32[4096,4] e:f32[4096,4]. let
          f:f32[4,4096] = transpose[permutation=(1, 0)] d
          g:f32[1,4096] = slice[
            limit_indices=(1, 4096)
            start_indices=(0, 0)
            strides=(1, 1)
          ] f
          h:f32[4096] = squeeze[dimensions=(0,)] g
          i:f32[1,4096] = slice[
            limit_indices=(2, 4096)
            start_indices=(1, 0)
            strides=(1, 1)
          ] f
          j:f32[4096] = squeeze[dimensions=(0,)] i
          k:f32[1,4096] = slice[
            limit_indices=(3, 4096)
            start_indices=(2, 0)
            strides=(1, 1)
          ] f
          l:f32[4096] = squeeze[dimensions=(0,)] k
          m:f32[1,4096] = slice[
            limit_indices=(4, 4096)
            start_indices=(3, 0)
            strides=(1, 1)
          ] f
          n:f32[4096] = squeeze[dimensions=(0,)] m
          o:f32[4,4096] = transpose[permutation=(1, 0)] e
          p:f32[1,4096] = slice[
            limit_indices=(1, 4096)
            start_indices=(0, 0)
            strides=(1, 1)
          ] o
          q:f32[4096] = squeeze[dimensions=(0,)] p
          r:f32[1,4096] = slice[
            limit_indices=(2, 4096)
            start_indices=(1, 0)
            strides=(1, 1)
          ] o
          s:f32[4096] = squeeze[dimensions=(0,)] r
          t:f32[1,4096] = slice[
            limit_indices=(3, 4096)
            start_indices=(2, 0)
            strides=(1, 1)
          ] o
          u:f32[4096] = squeeze[dimensions=(0,)] t
          v:f32[1,4096] = slice[
            limit_indices=(4, 4096)
            start_indices=(3, 0)
            strides=(1, 1)
          ] o
          w:f32[4096] = squeeze[dimensions=(0,)] v
          x:f32[4096] = neg j
          y:f32[4096] = mul x s
          z:f32[4096] = mul l u
          ba:f32[4096] = sub y z
          bb:f32[4096] = mul n w
          bc:f32[4096] = sub ba bb
          bd:f32[4096] = mul h q
          be:f32[4096] = add bc bd
          bf:f32[4096] = mul j q
          bg:f32[4096] = mul l w
          bh:f32[4096] = add bf bg
          bi:f32[4096] = mul n u
          bj:f32[4096] = sub bh bi
          bk:f32[4096] = mul h s
          bl:f32[4096] = add bj bk
          bm:f32[4096] = neg j
          bn:f32[4096] = mul bm w
          bo:f32[4096] = mul l q
          bp:f32[4096] = add bn bo
          bq:f32[4096] = mul n s
          br:f32[4096] = add bp bq
          bs:f32[4096] = mul h u
          bt:f32[4096] = add br bs
          bu:f32[4096] = mul j u
          bv:f32[4096] = mul l s
          bw:f32[4096] = sub bu bv
          bx:f32[4096] = mul n q
          by:f32[4096] = add bw bx
          bz:f32[4096] = mul h w
          ca:f32[4096] = add by bz
          cb:f32[4096,1] = broadcast_in_dim[
            broadcast_dimensions=(0,)
            shape=(4096, 1)
          ] be
          cc:f32[4096,1] = broadcast_in_dim[
            broadcast_dimensions=(0,)
            shape=(4096, 1)
          ] bl
          cd:f32[4096,1] = broadcast_in_dim[
            broadcast_dimensions=(0,)
            shape=(4096, 1)
          ] bt
          ce:f32[4096,1] = broadcast_in_dim[
            broadcast_dimensions=(0,)
            shape=(4096, 1)
          ] ca
          cf:f32[4096,4] = concatenate[dimension=1] cb cc cd ce
        in (cf,) }
    ] a b
  in (c,) }
```